### PR TITLE
Use actual statsd_graphite_raw value, not it's length

### DIFF
--- a/templates/statsd.js.j2
+++ b/templates/statsd.js.j2
@@ -124,7 +124,7 @@ Optional Variables:
 {% endif %}
 
 {% if statsd_graphite_raw is defined and statsd_graphite_raw is not none  %}
-, graphite: {{ statsd_graphite_raw|length }}
+, graphite: {{ statsd_graphite_raw }}
 {% endif %}
 
 {% if statsd_influxdb_raw is defined and statsd_influxdb_raw is not none  %}


### PR DESCRIPTION
Not sure why this change went in, but it effectively breaks graphite backend configuration.
So I basically reverted it to what it was before.