### PR TITLE
feat: allow version in npm extra packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ statsd_graphite:
   legacyNamespace: false
 
 statsd_additional_options: {}       # Setup additional options
+
+# Extra NPM dependencies. For example if your config.js depends on to something
+# if version package is omitted, assumes current version available at npm
+# { name: pkg, version: "1.2.3" }
+statsd_extra_dependencies: []
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ statsd_graphite:
 statsd_additional_options: {}       # Setup additional options
 
 # Extra NPM dependencies. For example if your config.js depends on to something
-# if version package is omitted, assumes current version available at npm
-# { name: pkg, version: "1.2.3" }
 statsd_extra_dependencies: []
+
+# Same then statsd_extra_dependencies with allow pin the version
+# { name: pkg, version: "1.2.3" }
+statsd_pined_extra_dependencies: []
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,4 +36,6 @@ statsd_additional_options: {}       # Setup additional options
 statsd_additional_options_raw: {}   # Setup additional options without piping values trough 'to_nice_json' filter
 
 # Extra NPM dependencies. For example if your config.js depends on to something
+# if version package is omitted, assumes current version available at npm
+# { name: pkg, version: "1.2.3" }
 statsd_extra_dependencies: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ statsd_additional_options: {}       # Setup additional options
 statsd_additional_options_raw: {}   # Setup additional options without piping values trough 'to_nice_json' filter
 
 # Extra NPM dependencies. For example if your config.js depends on to something
-# if version package is omitted, assumes current version available at npm
-# { name: pkg, version: "1.2.3" }
 statsd_extra_dependencies: []
+
+# Same then statsd_extra_dependencies with allow pin the version
+# { name: pkg, version: "1.2.3" }
+statsd_pined_extra_dependencies: []

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -5,22 +5,13 @@
 - name: Install statsd
   npm: name=statsd path={{statsd_home}}
 
-- name: Support to deprecated NPM extra package variable
-  block:
-    - debug:
-        msg: "[WARNING]: Consider using statsd_extra_dependencies passing name and version instead only string package name, ex: statsd_extra_dependencies: [{ name: pkg, version: 1.2.3 }]"
-
-    - set_fact:
-        statsd_extra_dependencies: "{{ [{'name': item}] }}"
-      with_items: "{{ statsd_extra_dependencies }}"
-
-  when:
-    - statsd_extra_dependencies | length > 0
-    - statsd_extra_dependencies | first is string
-
 - name: Install extra NPM dependencies
-  npm: name={{item.name}} version={{item.version | d(omit)}} path={{statsd_home}}
+  npm: name={{item.name}} path={{statsd_home}}
   with_items: "{{ statsd_extra_dependencies }}"
+
+- name: Install pined extra NPM dependencies
+  npm: name={{item.name}} version={{item.version | d(omit)}} path={{statsd_home}}
+  with_items: "{{ statsd_pined_extra_dependencies }}"
 
 - name: Create node user
   user: name={{statsd_user}} state=present shell=/bin/false system=yes

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -1,14 +1,26 @@
 ---
-
 - name: Prepare Statsd directory
   file: state=directory path={{statsd_home}}
 
 - name: Install statsd
   npm: name=statsd path={{statsd_home}}
 
+- name: Support to deprecated NPM extra package variable
+  block:
+    - debug:
+        msg: "[WARNING]: Consider using statsd_extra_dependencies passing name and version instead only string package name, ex: statsd_extra_dependencies: [{ name: pkg, version: 1.2.3 }]"
+
+    - set_fact:
+        statsd_extra_dependencies: "{{ [{'name': item}] }}"
+      with_items: "{{ statsd_extra_dependencies }}"
+
+  when:
+    - statsd_extra_dependencies | length > 0
+    - statsd_extra_dependencies | first is string
+
 - name: Install extra NPM dependencies
-  npm: name={{item}} path={{statsd_home}}
-  with_items: "{{statsd_extra_dependencies}}"
+  npm: name={{item.name}} version={{item.version | d(omit)}} path={{statsd_home}}
+  with_items: "{{ statsd_extra_dependencies }}"
 
 - name: Create node user
   user: name={{statsd_user}} state=present shell=/bin/false system=yes


### PR DESCRIPTION
Sometimes we need freeze npm dependencies and this PR add support to pass
npm version into `statsd_pined_extra_dependencies` variable as follow the
example:
```yml
statsd_pined_extra_dependencies:
  - name: pkg_name
    version: 1.2.3
```